### PR TITLE
delete files in all cases to avoid 'from' and 'to' are of different l…

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -45,6 +45,7 @@ main <- function() {
           cat(prettify(error_json))
           post_job(error_queue, error_json, "error")
         }, finally = {
+          delete_files()
           message("Deleting job from SQS ...")
           delete_msg(from_queue, message$ReceiptHandle)
           message("Garbage collection ...")

--- a/R/processing.R
+++ b/R/processing.R
@@ -5,7 +5,6 @@ process_package <- function(pkg_url, pkg_name, repo_type) {
   pkg_folder <- download_and_unpack(pkg_url, pkg_name)
   description <- parse_description(pkg_folder, repo_type)
   topics <- parse_topics(pkg_folder)
-  delete_files()
   return(list(description = description,
               topics = topics))
 }


### PR DESCRIPTION
` 'from' and 'to' are of different length` errors were piling up on the dead letter queue.
This seems to occurs when something is already in the directory `packages/` and he tries to unpack a new one.

What probably happened is that a package errored out, was not cleaned up because it didn't reach the cleaning logic and then all the subsequent ones failed to unpack.

I moved the cleaning logic in the `finally` so it happens no matters what.

I'm merging it since it's pretty important, but do a PR anyway so you can review when back ;) 